### PR TITLE
Fix QR scanner import to use Scanner component

### DIFF
--- a/app/src/components/QRScanner.tsx
+++ b/app/src/components/QRScanner.tsx
@@ -1,11 +1,15 @@
 'use client';
 import dynamic from 'next/dynamic';
 
-const QrScanner = dynamic(
-  () => import('@yudiel/react-qr-scanner').then(m => m.QrScanner),
+const Scanner = dynamic(
+  () => import('@yudiel/react-qr-scanner').then(m => m.Scanner),
   { ssr: false }
 );
 
 export default function QRScanner({ onResult }: { onResult: (text: string) => void }) {
-  return <QrScanner onDecode={onResult} />;
+  return (
+    <Scanner
+      onScan={detectedCodes => onResult(detectedCodes[0]?.rawValue ?? '')}
+    />
+  );
 }

--- a/src/components/QRScanner.tsx
+++ b/src/components/QRScanner.tsx
@@ -1,11 +1,15 @@
 'use client';
 import dynamic from 'next/dynamic';
 
-const QrScanner = dynamic(
-  () => import('@yudiel/react-qr-scanner').then(m => m.QrScanner),
+const Scanner = dynamic(
+  () => import('@yudiel/react-qr-scanner').then(m => m.Scanner),
   { ssr: false }
 );
 
 export default function QRScanner({ onResult }: { onResult: (text: string) => void }) {
-  return <QrScanner onDecode={onResult} />;
+  return (
+    <Scanner
+      onScan={detectedCodes => onResult(detectedCodes[0]?.rawValue ?? '')}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- fix dynamic import to use `Scanner` from `@yudiel/react-qr-scanner`
- forward scan results to callback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80cf6ecc08330a79ac0068200acc2